### PR TITLE
Retry/backoff wrapper for flaky nlm operations

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -18,6 +18,9 @@ jobs:
       - name: ShellCheck
         run: shellcheck -x scripts/*.sh
 
+      - name: Retry helper self-test
+        run: bash tests/retry-helper-test.sh
+
       - name: Python compile
         run: python3 -m py_compile lib/*.py
 

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared retry/backoff helper for transient failures.
+#
+# Configuration (env vars):
+#   NLM_RETRY_ATTEMPTS   (default: 3)
+#   NLM_RETRY_BASE_SLEEP (default: 1)
+#   NLM_RETRY_MAX_SLEEP  (default: 8)
+#   NLM_RETRY_EXIT_CODES (optional, space-separated; if set, only retry these codes)
+#   NLM_NO_RETRY         ("true" disables retries; scripts wire this from --no-retry)
+
+_nlm__is_int() {
+  [[ "${1:-}" =~ ^[0-9]+$ ]]
+}
+
+_nlm__exit_code_retryable() {
+  local rc="$1"
+
+  if [[ -z "${NLM_RETRY_EXIT_CODES:-}" ]]; then
+    return 0
+  fi
+
+  local c
+  for c in $NLM_RETRY_EXIT_CODES; do
+    if [[ "$c" == "$rc" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+retry_cmd() {
+  local desc="$1"
+  shift
+
+  local max_attempts="${NLM_RETRY_ATTEMPTS:-3}"
+  local base_sleep="${NLM_RETRY_BASE_SLEEP:-1}"
+  local max_sleep="${NLM_RETRY_MAX_SLEEP:-8}"
+
+  if ! _nlm__is_int "$max_attempts" || [[ "$max_attempts" -lt 1 ]]; then
+    echo "[retry] invalid NLM_RETRY_ATTEMPTS=$max_attempts (expected int >= 1)" >&2
+    max_attempts=3
+  fi
+  if ! _nlm__is_int "$base_sleep"; then
+    echo "[retry] invalid NLM_RETRY_BASE_SLEEP=$base_sleep (expected int)" >&2
+    base_sleep=1
+  fi
+  if ! _nlm__is_int "$max_sleep"; then
+    echo "[retry] invalid NLM_RETRY_MAX_SLEEP=$max_sleep (expected int)" >&2
+    max_sleep=8
+  fi
+
+  local attempt=1
+  local rc=0
+
+  while true; do
+    # Preserve caller's errexit behavior while allowing the command to fail
+    # without aborting the entire script (required for retry loops).
+    local errexit_was_set=0
+    case $- in
+      *e*) errexit_was_set=1 ;;
+    esac
+    set +e
+    "$@"
+    rc=$?
+    if [[ $errexit_was_set -eq 1 ]]; then
+      set -e
+    fi
+
+    if [[ $rc -eq 0 ]]; then
+      return 0
+    fi
+
+    if [[ "${NLM_NO_RETRY:-false}" == "true" ]]; then
+      return "$rc"
+    fi
+
+    if [[ $attempt -ge $max_attempts ]]; then
+      return "$rc"
+    fi
+
+    if ! _nlm__exit_code_retryable "$rc"; then
+      return "$rc"
+    fi
+
+    # Exponential backoff (base * 2^(attempt-1)), clamped.
+    local sleep_s=$(( base_sleep * (1 << (attempt - 1)) ))
+    if [[ $sleep_s -gt $max_sleep ]]; then
+      sleep_s=$max_sleep
+    fi
+
+    echo "[retry] $desc: attempt $attempt/$max_attempts failed (exit $rc); retrying in ${sleep_s}s" >&2
+    sleep "$sleep_s"
+    attempt=$(( attempt + 1 ))
+  done
+}

--- a/tests/retry-helper-test.sh
+++ b/tests/retry-helper-test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)"
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/retry.sh"
+
+failures=0
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "assert failed: $msg (expected=$expected actual=$actual)" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+test_default_retries() {
+  local attempts=0
+  flaky() {
+    attempts=$((attempts + 1))
+    if [[ $attempts -lt 3 ]]; then
+      return 7
+    fi
+    return 0
+  }
+
+  NLM_NO_RETRY=false NLM_RETRY_ATTEMPTS=3 NLM_RETRY_BASE_SLEEP=0 NLM_RETRY_MAX_SLEEP=0 retry_cmd "flaky default" flaky
+  assert_eq "3" "$attempts" "default retries should try 3 times and succeed"
+}
+
+test_insufficient_retries_fails() {
+  local attempts=0
+  flaky() {
+    attempts=$((attempts + 1))
+    return 7
+  }
+
+  set +e
+  NLM_NO_RETRY=false NLM_RETRY_ATTEMPTS=2 NLM_RETRY_BASE_SLEEP=0 NLM_RETRY_MAX_SLEEP=0 retry_cmd "flaky insufficient" flaky
+  local rc=$?
+  set -e
+
+  assert_eq "7" "$rc" "should return last exit code when retries exhausted"
+  assert_eq "2" "$attempts" "should try exactly NLM_RETRY_ATTEMPTS times"
+}
+
+test_no_retry() {
+  local attempts=0
+  flaky() {
+    attempts=$((attempts + 1))
+    return 7
+  }
+
+  set +e
+  NLM_NO_RETRY=true NLM_RETRY_ATTEMPTS=5 NLM_RETRY_BASE_SLEEP=0 NLM_RETRY_MAX_SLEEP=0 retry_cmd "flaky no-retry" flaky
+  local rc=$?
+  set -e
+
+  assert_eq "7" "$rc" "no-retry should return immediately"
+  assert_eq "1" "$attempts" "no-retry should only try once"
+}
+
+test_default_retries
+test_insufficient_retries_fails
+test_no_retry
+
+if [[ $failures -ne 0 ]]; then
+  echo "retry helper tests failed: $failures" >&2
+  exit 1
+fi
+
+echo "retry helper tests: ok"


### PR DESCRIPTION
Implements Issue #6.

Changes:
- Added shared retry helper: scripts/retry.sh (exponential backoff; configurable via env; can be disabled)
- Added --no-retry flag to key scripts and propagated it from automate-notebook.sh
- Wrapped flaky nlm operations with retry_cmd in:
  - scripts/add-sources.sh (add url/text/drive)
  - scripts/generate-studio.sh (create/status/download)
  - scripts/export-notebook.sh (list/download/content)
  - scripts/export-all.sh (notebook list + fixed export-notebook invocation)
  - scripts/create-notebook.sh (create)
  - scripts/generate-parallel.sh (download placeholder + pass-through)
- Added retry helper self-test: tests/retry-helper-test.sh
- Wired self-test into CI: .github/workflows/static-checks.yml

Notes:
- stderr is no longer discarded for nlm create/download calls (previous 2>/dev/null patterns were hiding actionable failures).
- export-all.sh and automate-notebook.sh now call export-notebook.sh with --output/--id (they were passing positional output args).
