### PR TITLE
Graceful failure when optional research deps are missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,16 @@ Be respectful and inclusive in all interactions. This project follows standard o
 ### Install Development Dependencies
 
 ```bash
-# Install Python dependencies for smart creation features
+# Optional: install Python dependencies for smart creation features
 pip3 install -r requirements-research.txt
 
 # Authenticate with NotebookLM
 nlm login
+```
+
+Note: If pip is blocked by an externally-managed environment, use a venv:
+```bash
+python3 -m venv .venv && . .venv/bin/activate && pip install -r requirements-research.txt
 ```
 
 ### Verify Setup

--- a/README.md
+++ b/README.md
@@ -421,14 +421,20 @@ Generate studio artifacts programmatically with polling until completion.
 
 Automatically create research notebooks from topics with smart source discovery.
 
+**Requires optional research dependencies:** `requests` + `ddgs` (only for smart research features).
+```bash
+pip3 install -r requirements-research.txt
+```
+
 **Usage:**
 ```bash
-./scripts/research-topic.sh "<topic>" [--depth N] [--auto-generate TYPES]
+./scripts/research-topic.sh "<topic>" [--depth N] [--auto-generate TYPES] [--no-retry]
 ```
 
 **Options:**
 - `--depth <N>` - Number of sources to find (default: 3)
 - `--auto-generate <types>` - Comma-separated artifact types to generate
+- `--no-retry` - Disable retry/backoff for `nlm` operations
 
 **Features:**
 - DuckDuckGo web search for quality sources


### PR DESCRIPTION
Implements Issue #8.

Changes:
- scripts/research-topic.sh:
  - Checks for optional Python deps (requests, ddgs) and exits with a clear install message if missing.
  - Adds --no-retry and forwards it to nlm helper scripts.
  - Stops swallowing helper stderr (no more redirecting everything to /dev/null).
- scripts/automate-notebook.sh:
  - Smart creation mode now checks for optional research deps and fails with an actionable error if missing.
  - Forwards --no-retry to research-topic.sh.
- README.md and CONTRIBUTING.md:
  - Clarify that research deps are optional and only required for smart research features.

Evidence: CI Static Checks runs on this PR.
