### PR TITLE
Chunk long text sources when adding text

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Retry helper self-test
         run: bash tests/retry-helper-test.sh
 
+      - name: Text chunking dry-run self-test
+        run: bash tests/text-chunking-dryrun-test.sh
+
       - name: Python compile
         run: python3 -m py_compile lib/*.py
 

--- a/README.md
+++ b/README.md
@@ -285,12 +285,13 @@ Add sources to an existing notebook with automatic type detection.
 
 **Usage:**
 ```bash
-./scripts/add-sources.sh <notebook-id> <source1> [source2] ...
+./scripts/add-sources.sh <notebook-id> <source1> [source2] ... [--text-chunk-size N]
 ```
 
 **Source types (auto-detected):**
 - URLs: `https://example.com/article`
 - Text content: `text:"Your content here"`
+- Text file (chunked): `textfile:/path/to/file.txt`
 - Google Drive: `drive://document-id`
 
 **Note:** File uploads not supported by nlm CLI. Upload files to Google Drive first, then add via `drive://` prefix.
@@ -300,6 +301,7 @@ Add sources to an existing notebook with automatic type detection.
 ./scripts/add-sources.sh "abc-123-def-456" \
   "https://www.anthropic.com" \
   "text:Claude is an AI assistant" \
+  "textfile:./long-notes.txt" \
   "drive://1A2B3C4D5E"
 ```
 

--- a/scripts/add-sources.sh
+++ b/scripts/add-sources.sh
@@ -5,6 +5,7 @@
 # Source types (auto-detected):
 #   - URLs: https://... or http://...
 #   - Text: text:content (prefix with "text:")
+#   - Text file: textfile:/path/to/file.txt (chunks long text into multiple sources)
 #   - Drive: drive://file-id (prefix with "drive://")
 #   - Files: /path/to/file (local files - NOT SUPPORTED YET)
 
@@ -31,6 +32,7 @@ Add sources to an existing NotebookLM notebook.
 Options:
   --dry-run    Print actions and exit without adding sources
   --no-retry   Disable retry/backoff for nlm operations
+  --text-chunk-size <N>  Chunk long text sources into parts of ~N characters (default: 8000)
   -h, --help   Show this help message
 
 Arguments:
@@ -40,12 +42,14 @@ Arguments:
 Source types (auto-detected):
   - URLs:  https://example.com/page
   - Text:  text:Your content here
+  - Text file: textfile:/path/to/file.txt
   - Drive: drive://1234567890abcdef
   - Files: /path/to/file (NOT SUPPORTED YET)
 
 Examples:
   $(basename "$0") nb-123 https://example.com
   $(basename "$0") nb-123 "text:My notes" https://example.com
+  $(basename "$0") nb-123 textfile:./notes.txt
   $(basename "$0") nb-123 drive://1abc234def
 
 Output:
@@ -60,6 +64,7 @@ EOF
 
 DRY_RUN=false
 NO_RETRY=false
+TEXT_CHUNK_SIZE=8000
 
 while [[ $# -gt 0 ]]; do
     case "${1:-}" in
@@ -75,6 +80,11 @@ while [[ $# -gt 0 ]]; do
             NO_RETRY=true
             shift
             ;;
+        --text-chunk-size)
+            [[ -z "${2:-}" ]] && { echo "Error: --text-chunk-size requires an argument" >&2; exit 2; }
+            TEXT_CHUNK_SIZE="$2"
+            shift 2
+            ;;
         *)
             break
             ;;
@@ -84,6 +94,23 @@ done
 if [[ "$NO_RETRY" == true ]]; then
     export NLM_NO_RETRY=true
 fi
+
+if [[ ! "$TEXT_CHUNK_SIZE" =~ ^[0-9]+$ ]] || [[ "$TEXT_CHUNK_SIZE" -lt 1 ]]; then
+    echo -e "${RED}Error: Invalid --text-chunk-size: $TEXT_CHUNK_SIZE (expected integer >= 1)${NC}" >&2
+    exit 2
+fi
+
+count_text_chunks() {
+    local text="$1"
+    local chunk_size="$2"
+    NLM_TEXT="$text" NLM_CHUNK="$chunk_size" python3 -c '
+import math, os
+text = os.environ.get("NLM_TEXT", "")
+chunk = int(os.environ.get("NLM_CHUNK", "8000"))
+n = max(1, math.ceil(len(text) / chunk))
+print(n)
+'
+}
 
 # Check arguments
 if [ $# -lt 2 ]; then
@@ -98,7 +125,31 @@ shift
 
 if [[ "$DRY_RUN" == true ]]; then
     for source in "$@"; do
-        echo "Would add to $NOTEBOOK_ID: $source" >&2
+        if [[ "$source" =~ ^textfile: ]]; then
+            path="${source#textfile:}"
+            if [[ -f "$path" ]]; then
+                text=$(python3 - "$path" <<'PY'
+import sys
+with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as f:
+  print(f.read())
+PY
+)
+                n=$(count_text_chunks "$text" "$TEXT_CHUNK_SIZE")
+                echo "Would add to $NOTEBOOK_ID: textfile:$path ($n chunk(s), size=$TEXT_CHUNK_SIZE)" >&2
+            else
+                echo "Would add to $NOTEBOOK_ID: textfile:$path (missing file)" >&2
+            fi
+        elif [[ "$source" =~ ^text: ]]; then
+            text_content="${source#text:}"
+            n=$(count_text_chunks "$text_content" "$TEXT_CHUNK_SIZE")
+            if [[ "$n" -gt 1 ]]; then
+                echo "Would add to $NOTEBOOK_ID: text:(chunked $n parts, size=$TEXT_CHUNK_SIZE)" >&2
+            else
+                echo "Would add to $NOTEBOOK_ID: $source" >&2
+            fi
+        else
+            echo "Would add to $NOTEBOOK_ID: $source" >&2
+        fi
     done
     NLM_NB_ID="$NOTEBOOK_ID" python3 -c 'import json, os; print(json.dumps({"notebook_id": os.environ["NLM_NB_ID"], "dry_run": True}))'
     exit 0
@@ -117,6 +168,74 @@ SOURCES_FAILED=0
 # Temporary file for collecting errors
 ERROR_LOG=$(mktemp)
 trap 'rm -f "$ERROR_LOG"' EXIT
+
+emit_text_chunks_b64() {
+    local label="$1"
+    local text="$2"
+    local chunk_size="$3"
+    NLM_LABEL="$label" NLM_TEXT="$text" NLM_CHUNK="$chunk_size" python3 - <<'PY'
+import base64
+import os
+
+label = os.environ.get("NLM_LABEL", "")
+text = os.environ.get("NLM_TEXT", "")
+chunk = int(os.environ.get("NLM_CHUNK", "8000"))
+parts = [text[i:i+chunk] for i in range(0, len(text), chunk)] or [""]
+n = len(parts)
+for i, p in enumerate(parts, 1):
+  header = f"[Part {i}/{n}]"
+  if label:
+    header += f" {label}"
+  out = header + "\n\n" + p
+  print(base64.b64encode(out.encode("utf-8")).decode("ascii"))
+PY
+}
+
+emit_textfile_chunks_b64() {
+    local path="$1"
+    local chunk_size="$2"
+    NLM_PATH="$path" NLM_CHUNK="$chunk_size" python3 - <<'PY'
+import base64
+import os
+
+path = os.environ["NLM_PATH"]
+chunk = int(os.environ.get("NLM_CHUNK", "8000"))
+
+with open(path, "r", encoding="utf-8", errors="replace") as f:
+  text = f.read()
+
+label = os.path.basename(path)
+parts = [text[i:i+chunk] for i in range(0, len(text), chunk)] or [""]
+n = len(parts)
+for i, p in enumerate(parts, 1):
+  header = f"[Part {i}/{n}] {label}"
+  out = header + "\n\n" + p
+  print(base64.b64encode(out.encode("utf-8")).decode("ascii"))
+PY
+}
+
+add_text_chunked_b64_stream() {
+    local what="$1"
+    local overall_rc=0
+    local chunk_num=0
+    local chunk_text
+
+    while IFS= read -r b64; do
+        chunk_num=$((chunk_num + 1))
+        chunk_text=$(printf '%s' "$b64" | python3 -c 'import sys, base64; print(base64.b64decode(sys.stdin.read()).decode("utf-8"))')
+        echo -e "${YELLOW}Adding text chunk $chunk_num:${NC} $what" >&2
+        if retry_cmd "nlm add text (chunk)" nlm add text "$NOTEBOOK_ID" "$chunk_text" 2>>"$ERROR_LOG"; then
+            ((SOURCES_ADDED++))
+            echo -e "${GREEN}✓ Added text chunk${NC}" >&2
+        else
+            ((SOURCES_FAILED++))
+            echo -e "${RED}✗ Failed to add text chunk${NC}" >&2
+            overall_rc=1
+        fi
+    done
+
+    return $overall_rc
+}
 
 # Function to detect source type and add it
 add_source() {
@@ -137,14 +256,32 @@ add_source() {
     elif [[ "$source" =~ ^text: ]]; then
         # Remove "text:" prefix
         local text_content="${source#text:}"
-        echo -e "${YELLOW}Adding text source${NC}" >&2
-        if retry_cmd "nlm add text" nlm add text "$NOTEBOOK_ID" "$text_content" 2>>"$ERROR_LOG"; then
-            ((SOURCES_ADDED++))
-            echo -e "${GREEN}✓ Added text source${NC}" >&2
+        text_len=$(printf '%s' "$text_content" | wc -c | tr -d ' ')
+        if [[ "$text_len" -gt "$TEXT_CHUNK_SIZE" ]]; then
+            echo -e "${YELLOW}Adding long text source (chunked)${NC} (~${text_len} chars, chunk size: $TEXT_CHUNK_SIZE)" >&2
+            emit_text_chunks_b64 "inline" "$text_content" "$TEXT_CHUNK_SIZE" | add_text_chunked_b64_stream "inline"
+            result=$?
         else
+            echo -e "${YELLOW}Adding text source${NC}" >&2
+            if retry_cmd "nlm add text" nlm add text "$NOTEBOOK_ID" "$text_content" 2>>"$ERROR_LOG"; then
+                ((SOURCES_ADDED++))
+                echo -e "${GREEN}✓ Added text source${NC}" >&2
+            else
+                ((SOURCES_FAILED++))
+                echo -e "${RED}✗ Failed to add text source${NC}" >&2
+                result=1
+            fi
+        fi
+    elif [[ "$source" =~ ^textfile: ]]; then
+        local path="${source#textfile:}"
+        if [[ ! -f "$path" ]]; then
+            echo -e "${RED}Error: textfile not found:${NC} $path" >&2
             ((SOURCES_FAILED++))
-            echo -e "${RED}✗ Failed to add text source${NC}" >&2
             result=1
+        else
+            echo -e "${YELLOW}Adding text file (chunked)${NC}: $path (chunk size: $TEXT_CHUNK_SIZE)" >&2
+            emit_textfile_chunks_b64 "$path" "$TEXT_CHUNK_SIZE" | add_text_chunked_b64_stream "$(basename "$path")"
+            result=$?
         fi
     elif [[ "$source" =~ ^drive:// ]]; then
         # Remove "drive://" prefix
@@ -168,6 +305,7 @@ add_source() {
         echo -e "${YELLOW}Supported formats:${NC}" >&2
         echo "  - URLs: https://... or http://..." >&2
         echo "  - Text: text:content" >&2
+        echo "  - Text file: textfile:/path/to/file.txt" >&2
         echo "  - Drive: drive://file-id" >&2
         echo "  - Files: /path/to/file (not yet supported)" >&2
         ((SOURCES_FAILED++))

--- a/tests/text-chunking-dryrun-test.sh
+++ b/tests/text-chunking-dryrun-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ADD_SOURCES="$ROOT_DIR/scripts/add-sources.sh"
+
+tmpfile="$(mktemp -t nlm-textfile.XXXXXX)"
+trap 'rm -f "$tmpfile"' EXIT
+
+python3 - <<PY >"$tmpfile"
+print("0123456789" * 50)
+PY
+
+out_inline="$("$ADD_SOURCES" --dry-run --text-chunk-size 10 nb-123 "text:0123456789abcdef" 2>&1)"
+if ! printf '%s\n' "$out_inline" | grep -q "chunked"; then
+  echo "expected inline text dry-run to mention chunking" >&2
+  exit 1
+fi
+
+out_file="$("$ADD_SOURCES" --dry-run --text-chunk-size 10 nb-123 "textfile:$tmpfile" 2>&1)"
+if ! printf '%s\n' "$out_file" | grep -q "textfile:.*chunk(s)"; then
+  echo "expected textfile dry-run to mention chunk count" >&2
+  exit 1
+fi
+
+echo "text chunking dry-run tests: ok"


### PR DESCRIPTION
Implements Issue #7.

Changes:
- scripts/add-sources.sh:
  - Adds support for textfile:/path/to/file.txt sources.
  - Adds --text-chunk-size N (default 8000) and automatically chunks long text:... sources.
  - Each chunk is prefixed with a header like [Part i/N] to preserve order.
  - Partial failures are tracked in sources_added/sources_failed counts.
- README.md:
  - Documents textfile: sources.
- tests/text-chunking-dryrun-test.sh:
  - Verifies chunking behavior via --dry-run (no nlm required).
- CI:
  - Adds the dry-run self-test to Static Checks.
