### PR TITLE
Centralize JSON parsing helpers for scripts

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Text chunking dry-run self-test
         run: bash tests/text-chunking-dryrun-test.sh
 
+      - name: JSON tools self-test
+        run: bash tests/json-tools-test.sh
+
       - name: Python compile
         run: python3 -m py_compile lib/*.py
 

--- a/lib/json_tools.py
+++ b/lib/json_tools.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Small JSON helper utilities for bash scripts.
+
+This module is intentionally dependency-free (stdlib only) and Python 3.8+ compatible.
+"""
+
+import argparse
+import json
+import sys
+from typing import Any, List, Dict
+
+
+def _read_json_stdin() -> Any:
+    try:
+        return json.load(sys.stdin)
+    except Exception as e:
+        print(f"Error: failed to parse JSON from stdin: {e}", file=sys.stderr)
+        raise
+
+
+def cmd_len(_: argparse.Namespace) -> int:
+    try:
+        obj = _read_json_stdin()
+    except Exception:
+        return 1
+    try:
+        print(len(obj))  # type: ignore[arg-type]
+        return 0
+    except Exception as e:
+        print(f"Error: object has no len(): {e}", file=sys.stderr)
+        return 1
+
+
+def _get_path(obj: Any, path: str) -> Any:
+    cur: Any = obj
+    for part in path.split("."):
+        if part == "":
+            raise KeyError("empty path segment")
+        # Allow list indexes: foo.0.bar
+        if isinstance(cur, list):
+            try:
+                idx = int(part)
+            except ValueError:
+                raise KeyError(f"expected list index, got: {part}")
+            cur = cur[idx]
+            continue
+        if isinstance(cur, dict):
+            if part not in cur:
+                raise KeyError(part)
+            cur = cur[part]
+            continue
+        raise KeyError(f"cannot traverse into non-container at segment: {part}")
+    return cur
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    try:
+        obj = _read_json_stdin()
+    except Exception:
+        return 1
+    try:
+        val = _get_path(obj, args.path)
+    except Exception as e:
+        print(f"Error: failed to get path '{args.path}': {e}", file=sys.stderr)
+        return 1
+
+    # Keep bash-friendly output: scalars as text, containers as JSON.
+    if isinstance(val, (dict, list)):
+        json.dump(val, sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+    if val is None:
+        print("null")
+        return 0
+    if isinstance(val, bool):
+        print("true" if val else "false")
+        return 0
+    print(val)
+    return 0
+
+
+def cmd_print_templates(_: argparse.Namespace) -> int:
+    try:
+        data = _read_json_stdin()
+    except Exception:
+        return 1
+
+    if not isinstance(data, list):
+        print("Error: expected a JSON array of templates", file=sys.stderr)
+        return 1
+
+    for t in data:
+        if not isinstance(t, dict):
+            continue
+        tid = t.get("id", "")
+        cat = t.get("category", "")
+        print(f"  {tid:30} ({cat})")
+    return 0
+
+
+def main(argv: List[str]) -> int:
+    p = argparse.ArgumentParser(prog="json_tools.py", add_help=True)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_len = sub.add_parser("len", help="Print len(JSON) from stdin")
+    sp_len.set_defaults(func=cmd_len)
+
+    sp_get = sub.add_parser("get", help="Get a dotted-path value from JSON stdin")
+    sp_get.add_argument("path", help="Dotted path (supports list indexes), e.g. title or items.0.id")
+    sp_get.set_defaults(func=cmd_get)
+
+    sp_tpl = sub.add_parser("print-templates", help="Pretty-print template list JSON to stdout")
+    sp_tpl.set_defaults(func=cmd_print_templates)
+
+    args = p.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+

--- a/scripts/automate-notebook.sh
+++ b/scripts/automate-notebook.sh
@@ -188,8 +188,8 @@ STUDIO_JSON=$(echo "$CONFIG_DATA" | python3 -c 'import sys, json; print(json.dum
 
 info "Config loaded successfully"
 info "  Title: $TITLE"
-info "  Sources: $(echo "$SOURCES_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')"
-info "  Studio artifacts: $(echo "$STUDIO_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')"
+info "  Sources: $(echo "$SOURCES_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)"
+info "  Studio artifacts: $(echo "$STUDIO_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)"
 if [[ "$DRY_RUN" == true ]]; then
     warn "Dry-run mode enabled: no changes will be made."
 fi
@@ -240,7 +240,7 @@ print(config.get("smart_creation", {}).get("depth", 5))
             info "  ./scripts/create-notebook.sh \"$TITLE\""
         fi
 
-        SOURCE_COUNT=$(echo "$SOURCES_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')
+        SOURCE_COUNT=$(echo "$SOURCES_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
         if [[ "$SOURCE_COUNT" -gt 0 ]]; then
             info "Would add sources ($SOURCE_COUNT):"
             while IFS= read -r source; do
@@ -257,7 +257,7 @@ print(config.get("smart_creation", {}).get("depth", 5))
         fi
     fi
 
-    STUDIO_COUNT=$(echo "$STUDIO_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')
+    STUDIO_COUNT=$(echo "$STUDIO_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
     if [[ "$STUDIO_COUNT" -gt 0 ]]; then
         info "Would generate artifacts ($STUDIO_COUNT):"
         if [[ "$PARALLEL_FLAG" == true && "$STUDIO_COUNT" -gt 1 ]]; then
@@ -439,7 +439,7 @@ if match:
   SOURCES_ADDED=0
   SOURCES_FAILED=0
 
-  SOURCE_COUNT=$(echo "$SOURCES_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')
+  SOURCE_COUNT=$(echo "$SOURCES_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
 
   if [[ "$SOURCE_COUNT" -eq 0 ]]; then
     warn "No sources to add"
@@ -487,7 +487,7 @@ section "Phase 3: Generating Studio Artifacts"
 ARTIFACTS_CREATED=0
 ARTIFACTS_FAILED=0
 
-STUDIO_COUNT=$(echo "$STUDIO_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')
+STUDIO_COUNT=$(echo "$STUDIO_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
 
 if [[ "$STUDIO_COUNT" -eq 0 ]]; then
     warn "No studio artifacts to generate"

--- a/scripts/create-from-template.sh
+++ b/scripts/create-from-template.sh
@@ -29,10 +29,7 @@ Examples:
 Available templates:
 EOF
   python3 "$SCRIPT_DIR/../lib/template_engine.py" list | \
-    python3 -c 'import sys, json
-templates = json.load(sys.stdin)
-for t in templates:
-    print("  {tid:30} ({cat})".format(tid=t.get("id", ""), cat=t.get("category", "")))'
+    python3 "$SCRIPT_DIR/../lib/json_tools.py" print-templates
   exit 0
 }
 

--- a/scripts/export-all.sh
+++ b/scripts/export-all.sh
@@ -90,7 +90,7 @@ if [[ $LIST_EXIT -ne 0 ]]; then
   echo "$NOTEBOOKS" >&2
   exit 2
 fi
-TOTAL=$(echo "$NOTEBOOKS" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+TOTAL=$(echo "$NOTEBOOKS" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len 2>/dev/null || echo 0)
 
 echo "Found $TOTAL notebooks to export"
 echo ""

--- a/scripts/export-notebook.sh
+++ b/scripts/export-notebook.sh
@@ -255,7 +255,7 @@ if [[ $SOURCES_EXIT -ne 0 ]]; then
   SOURCES="[]"
 fi
 echo "$SOURCES" > "$OUTPUT_DIR/sources/index.json"
-SOURCE_COUNT=$(echo "$SOURCES" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+SOURCE_COUNT=$(echo "$SOURCES" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len 2>/dev/null || echo 0)
 echo "  [+] sources/index.json ($SOURCE_COUNT sources)"
 
 # Try to get source content for each source
@@ -300,7 +300,7 @@ if [[ $NOTES_EXIT -ne 0 ]]; then
 fi
 if echo "$NOTES_OUTPUT" | python3 -c 'import sys, json; json.load(sys.stdin)' 2>/dev/null; then
   echo "$NOTES_OUTPUT" > "$OUTPUT_DIR/notes/index.json"
-  NOTE_COUNT=$(echo "$NOTES_OUTPUT" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')
+  NOTE_COUNT=$(echo "$NOTES_OUTPUT" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
   echo "  [+] notes/index.json ($NOTE_COUNT notes)"
   echo "$NOTES_OUTPUT" | python3 -c '
 import sys, json
@@ -333,7 +333,7 @@ if [[ $ARTIFACTS_EXIT -ne 0 ]]; then
   ARTIFACTS="[]"
 fi
 echo "$ARTIFACTS" > "$OUTPUT_DIR/studio/manifest.json"
-ARTIFACT_COUNT=$(echo "$ARTIFACTS" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))' 2>/dev/null || echo 0)
+ARTIFACT_COUNT=$(echo "$ARTIFACTS" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len 2>/dev/null || echo 0)
 echo "  [+] studio/manifest.json ($ARTIFACT_COUNT artifacts)"
 
 download_artifact() {

--- a/scripts/research-topic.sh
+++ b/scripts/research-topic.sh
@@ -144,7 +144,7 @@ depth = int(os.environ["NLM_DEPTH"])
 print(json.dumps(sources[:depth]))
 ')
 
-SOURCE_COUNT=$(echo "$SOURCES_JSON" | python3 -c 'import sys, json; print(len(json.load(sys.stdin)))')
+SOURCE_COUNT=$(echo "$SOURCES_JSON" | python3 "$SCRIPT_DIR/../lib/json_tools.py" len)
 echo "  Final: $SOURCE_COUNT unique sources"
 
 # Step 2: Create notebook with sources

--- a/tests/json-tools-test.sh
+++ b/tests/json-tools-test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOOLS="$ROOT_DIR/lib/json_tools.py"
+
+out_len="$(printf '[1,2,3]' | python3 "$TOOLS" len)"
+if [[ "$out_len" != "3" ]]; then
+  echo "expected len=3, got: $out_len" >&2
+  exit 1
+fi
+
+out_get="$(printf '{\"a\":{\"b\":[{\"id\":\"x\"}]}}' | python3 "$TOOLS" get a.b.0.id)"
+if [[ "$out_get" != "x" ]]; then
+  echo "expected get=a.b.0.id to be x, got: $out_get" >&2
+  exit 1
+fi
+
+out_tpl="$(printf '[{\"id\":\"research/academic-paper\",\"category\":\"research\"}]' | python3 "$TOOLS" print-templates)"
+printf '%s\n' "$out_tpl" | grep -q "research/academic-paper" || {
+  echo "expected print-templates to include template id" >&2
+  exit 1
+}
+
+echo "json tools tests: ok"
+


### PR DESCRIPTION
Implements Issue #9.

Changes:
- Added lib/json_tools.py (stdlib-only):
  - len: print len(JSON) from stdin
  - get: fetch dotted-path values (supports list indexes)
  - print-templates: pretty-print template list JSON
- Replaced the most common inline python patterns across scripts with json_tools:
  - scripts/automate-notebook.sh, scripts/export-notebook.sh, scripts/export-all.sh, scripts/research-topic.sh
  - scripts/create-from-template.sh template listing formatting
- Added tests/json-tools-test.sh and wired it into CI Static Checks.

Evidence: CI Static Checks runs on this PR.
