### PR TITLE
Standardize CLI output modes (--json/--quiet/--verbose)

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -27,6 +27,9 @@ jobs:
       - name: JSON tools self-test
         run: bash tests/json-tools-test.sh
 
+      - name: Help flags self-test
+        run: bash tests/help-flags-test.sh
+
       - name: Python compile
         run: python3 -m py_compile lib/*.py
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -13,13 +13,19 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+JSON_OUTPUT=true
+QUIET=false
+VERBOSE=false
+
 PASS_COUNT=0
 WARN_COUNT=0
 FAIL_COUNT=0
 
-pass() { ((PASS_COUNT++)); echo -e "${GREEN}PASS${NC} $*"; }
-warn() { ((WARN_COUNT++)); echo -e "${YELLOW}WARN${NC} $*"; }
-fail() { ((FAIL_COUNT++)); echo -e "${RED}FAIL${NC} $*"; }
+pass() { ((PASS_COUNT++)); if [[ "$QUIET" != true ]]; then echo -e "${GREEN}PASS${NC} $*" >&2; fi }
+warn() { ((WARN_COUNT++)); echo -e "${YELLOW}WARN${NC} $*" >&2; }
+fail() { ((FAIL_COUNT++)); echo -e "${RED}FAIL${NC} $*" >&2; }
+
+debug() { if [[ "$VERBOSE" == true && "$QUIET" != true ]]; then echo "Debug: $*" >&2; fi }
 
 show_help() {
   cat <<EOF
@@ -28,6 +34,9 @@ Usage: doctor.sh [options]
 Run preflight diagnostics for notebooklm-automation.
 
 Options:
+  --json         Emit JSON summary on stdout (default)
+  --quiet        Suppress non-critical logs
+  --verbose      Print additional diagnostics
   -h, --help     Show this help message
 
 Checks:
@@ -48,9 +57,36 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   exit 0
 fi
 
-echo -e "${BLUE}=== notebooklm-automation diagnostics ===${NC}"
-echo "Repo: $REPO_ROOT"
-echo ""
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --json)
+      JSON_OUTPUT=true
+      shift
+      ;;
+    --quiet)
+      QUIET=true
+      shift
+      ;;
+    --verbose)
+      VERBOSE=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+debug "verbose enabled"
+
+echo -e "${BLUE}=== notebooklm-automation diagnostics ===${NC}" >&2
+echo "Repo: $REPO_ROOT" >&2
+echo "" >&2
 
 check_cmd() {
   local name="$1"
@@ -69,15 +105,15 @@ check_cmd() {
   return 0
 }
 
-echo "Tooling:"
+echo "Tooling:" >&2
 check_cmd bash true || true
 check_cmd python3 true || true
 check_cmd nlm true || true
 check_cmd shellcheck false || true
 check_cmd jq false || true
-echo ""
+echo "" >&2
 
-echo "NotebookLM auth:"
+echo "NotebookLM auth:" >&2
 if command -v nlm >/dev/null 2>&1; then
   # Prefer a non-interactive status check.
   if nlm login --status >/dev/null 2>&1; then
@@ -88,9 +124,9 @@ if command -v nlm >/dev/null 2>&1; then
 else
   fail "nlm missing; cannot check authentication"
 fi
-echo ""
+echo "" >&2
 
-echo "Python deps (optional, for smart creation):"
+echo "Python deps (optional, for smart creation):" >&2
 if command -v python3 >/dev/null 2>&1; then
   if python3 -c 'import requests' >/dev/null 2>&1; then
     pass "Python module available: requests"
@@ -106,9 +142,9 @@ if command -v python3 >/dev/null 2>&1; then
 else
   fail "python3 missing; cannot check Python deps"
 fi
-echo ""
+echo "" >&2
 
-echo "Permissions:"
+echo "Permissions:" >&2
 perm_fail=false
 while IFS= read -r f; do
   if [[ ! -x "$f" ]]; then
@@ -127,9 +163,9 @@ done < <(find "$REPO_ROOT/lib" -maxdepth 1 -type f -name "*.py" -print)
 if [[ "$perm_fail" == "false" ]]; then
   pass "All scripts are executable"
 fi
-echo ""
+echo "" >&2
 
-echo "Template JSON validity:"
+echo "Template JSON validity:" >&2
 json_fail=false
 while IFS= read -r f; do
   if ! python3 -c 'import json,sys; json.load(open(sys.argv[1], "r", encoding="utf-8"))' "$f" >/dev/null 2>&1; then
@@ -141,20 +177,32 @@ done < <(find "$REPO_ROOT/templates" -type f -name "*.json" -print)
 if [[ "$json_fail" == "false" ]]; then
   pass "All templates are valid JSON"
 fi
-echo ""
+echo "" >&2
 
-echo "Network (best-effort):"
+echo "Network (best-effort):" >&2
 if python3 -c 'import socket; socket.gethostbyname("notebooklm.google.com")' >/dev/null 2>&1; then
   pass "DNS resolution OK: notebooklm.google.com"
 else
   warn "DNS resolution failed for notebooklm.google.com (may be transient)."
 fi
-echo ""
+echo "" >&2
 
-echo -e "${BLUE}=== Summary ===${NC}"
-echo "PASS: $PASS_COUNT"
-echo "WARN: $WARN_COUNT"
-echo "FAIL: $FAIL_COUNT"
+echo -e "${BLUE}=== Summary ===${NC}" >&2
+echo "PASS: $PASS_COUNT" >&2
+echo "WARN: $WARN_COUNT" >&2
+echo "FAIL: $FAIL_COUNT" >&2
+
+if [[ "$JSON_OUTPUT" == true ]]; then
+  NLM_PASS="$PASS_COUNT" NLM_WARN="$WARN_COUNT" NLM_FAIL="$FAIL_COUNT" python3 -c '
+import json, os
+fail = int(os.environ["NLM_FAIL"])
+print(json.dumps({
+  "pass": int(os.environ["NLM_PASS"]),
+  "warn": int(os.environ["NLM_WARN"]),
+  "fail": fail,
+  "status": "fail" if fail > 0 else "ok",
+}))'
+fi
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
   exit 1

--- a/tests/help-flags-test.sh
+++ b/tests/help-flags-test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+scripts=(
+  "$ROOT_DIR/scripts/add-sources.sh"
+  "$ROOT_DIR/scripts/automate-notebook.sh"
+  "$ROOT_DIR/scripts/create-from-template.sh"
+  "$ROOT_DIR/scripts/create-notebook.sh"
+  "$ROOT_DIR/scripts/doctor.sh"
+  "$ROOT_DIR/scripts/download-gdoc-md.sh"
+  "$ROOT_DIR/scripts/export-all.sh"
+  "$ROOT_DIR/scripts/export-notebook.sh"
+  "$ROOT_DIR/scripts/generate-parallel.sh"
+  "$ROOT_DIR/scripts/generate-studio.sh"
+  "$ROOT_DIR/scripts/research-topic.sh"
+  "$ROOT_DIR/scripts/validate-json.sh"
+)
+
+for s in "${scripts[@]}"; do
+  out="$("$s" --help 2>&1 || true)"
+  printf '%s\n' "$out" | grep -q -- "--json" || { echo "missing --json in help: $s" >&2; exit 1; }
+  printf '%s\n' "$out" | grep -q -- "--quiet" || { echo "missing --quiet in help: $s" >&2; exit 1; }
+  printf '%s\n' "$out" | grep -q -- "--verbose" || { echo "missing --verbose in help: $s" >&2; exit 1; }
+done
+
+echo "help flags tests: ok"
+


### PR DESCRIPTION
Implements Issue #3.

Changes:
- Added common output-mode flags across scripts:
  - --json (default): emit a single JSON object on stdout
  - --quiet: suppress non-critical logs (logs go to stderr)
  - --verbose: placeholder for extra diagnostics
- Moved human-readable logs/progress to stderr in scripts that previously printed to stdout.
- Added JSON summaries to scripts that previously lacked a machine-readable summary (notably export-notebook.sh, export-all.sh, generate-parallel.sh, research-topic.sh, doctor.sh, download-gdoc-md.sh, validate-json.sh).
- Added tests/help-flags-test.sh and wired it into CI Static Checks to ensure every script advertises the new flags.

Evidence: CI Static Checks runs on this PR.
