### PR TITLE
P1: improve integration-test coverage + document maintainer workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,13 +123,29 @@ Fixes #456
 ### Run Tests Before Committing
 
 ```bash
-# Run all integration tests
+# CI-equivalent no-auth checks (fast)
+bash -n scripts/*.sh
+shellcheck -x scripts/*.sh
+python3 -m py_compile lib/*.py
+
+bash tests/help-flags-test.sh
+bash tests/dry-run-smoke-test.sh
+bash tests/json-tools-test.sh
+bash tests/retry-helper-test.sh
+
+# Integration tests (requires nlm login; creates and deletes notebooks; takes a few minutes)
+nlm login
 ./tests/integration-test.sh
 
 # Test specific functionality
 ./scripts/export-notebook.sh "test-notebook" /tmp/test-export
 ./scripts/automate-notebook.sh --config tests/fixtures/example-config.json
 ```
+
+Integration test notes:
+- By default it creates one notebook and runs live `nlm` operations against it, then deletes it in cleanup.
+- Use `./tests/integration-test.sh --keep-notebooks` to keep notebooks for debugging.
+- `./tests/integration-test.sh --run-export-all` will export all notebooks (slow; maintainer-only).
 
 ### Add Tests for New Features
 

--- a/README.md
+++ b/README.md
@@ -754,6 +754,27 @@ Large notebooks with many artifacts (especially audio/video) can take time:
 
 ## Testing
 
+### Running tests
+
+CI runs no-auth checks only. Locally you can run:
+
+```bash
+# CI-equivalent no-auth checks
+bash -n scripts/*.sh
+shellcheck -x scripts/*.sh
+python3 -m py_compile lib/*.py
+
+bash tests/help-flags-test.sh
+bash tests/dry-run-smoke-test.sh
+```
+
+For a true end-to-end run (requires a real NotebookLM login; creates and deletes test notebooks):
+
+```bash
+nlm login
+./tests/integration-test.sh
+```
+
 Smoke tests verified (2026-02-06):
 - ✅ Authentication (42 cookies extracted)
 - ✅ List notebooks (80 found)

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -8,6 +8,7 @@
 # 3. Studio artifact generation (quiz)
 # 4. Export functionality
 # 5. End-to-end automation from config
+# 6. Additional workflow coverage (generate-parallel, template rendering, help flags)
 #
 # Features:
 # - Automatic cleanup of test notebooks
@@ -17,6 +18,16 @@
 #
 
 set -euo pipefail
+
+# shellcheck disable=SC2329
+# Usage:
+#   ./tests/integration-test.sh [options]
+#
+# Options:
+#   --keep-notebooks    Do not delete created notebooks on exit
+#   --run-export-all    Also run export-all.sh (WARNING: exports all notebooks)
+#   -h, --help          Show this help
+#
 
 # Colors for output
 RED='\033[0;31m'
@@ -29,14 +40,49 @@ NC='\033[0m' # No Color
 PASSED=0
 FAILED=0
 
+# Options
+KEEP_NOTEBOOKS=false
+RUN_EXPORT_ALL=false
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-notebooks)
+            KEEP_NOTEBOOKS=true
+            shift
+            ;;
+        --run-export-all)
+            RUN_EXPORT_ALL=true
+            shift
+            ;;
+        -h|--help)
+            cat <<EOF
+Usage: ./tests/integration-test.sh [options]
+
+Options:
+  --keep-notebooks    Do not delete created notebooks on exit
+  --run-export-all    Also run export-all.sh (WARNING: exports all notebooks)
+  -h, --help          Show this help
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            echo "Try --help for usage." >&2
+            exit 2
+            ;;
+    esac
+done
+
 # Array to track created notebooks for cleanup
 CREATED_NOTEBOOKS=()
 
 # Temp directory setup
-TEMP_DIR=$(mktemp -d)
-trap cleanup EXIT
+TEMP_DIR=$(mktemp -d -t nlm-integration.XXXXXX)
+trap 'cleanup' EXIT
 
 # Cleanup function
+# shellcheck disable=SC2329
 cleanup() {
     local exit_code=$?
 
@@ -44,7 +90,11 @@ cleanup() {
     echo -e "${BLUE}==== Cleanup ====${NC}"
 
     # Delete all test notebooks
-    cleanup_notebooks
+    if [[ "$KEEP_NOTEBOOKS" == true ]]; then
+        warn "Keeping ${#CREATED_NOTEBOOKS[@]} created notebook(s) (--keep-notebooks)"
+    else
+        cleanup_notebooks
+    fi
 
     # Remove temp directory
     if [[ -d "$TEMP_DIR" ]]; then
@@ -56,6 +106,7 @@ cleanup() {
 }
 
 # Function to delete all test notebooks
+# shellcheck disable=SC2329
 cleanup_notebooks() {
     if [[ ${#CREATED_NOTEBOOKS[@]} -eq 0 ]]; then
         echo "No test notebooks to clean up"
@@ -67,9 +118,9 @@ cleanup_notebooks() {
     for notebook_id in "${CREATED_NOTEBOOKS[@]}"; do
         echo -n "  Deleting $notebook_id... "
         if nlm delete notebook "$notebook_id" -y >/dev/null 2>&1; then
-            echo -e "${GREEN}✓${NC}"
+            echo -e "${GREEN}OK${NC}"
         else
-            echo -e "${YELLOW}⚠ (may have been already deleted)${NC}"
+            echo -e "${YELLOW}WARN (may have been already deleted)${NC}"
         fi
     done
 }
@@ -102,8 +153,78 @@ test_failed() {
     error "✗ FAILED: $1"
 }
 
+require_cmd() {
+    local name="$1"
+    if ! command -v "$name" >/dev/null 2>&1; then
+        error "Missing required command: $name"
+        exit 2
+    fi
+}
+
+require_nlm_login() {
+    if ! nlm login --status >/dev/null 2>&1; then
+        error "NotebookLM CLI is not authenticated."
+        echo "Run: nlm login" >&2
+        exit 2
+    fi
+}
+
+_safe_name() {
+    local s="$1"
+    s="${s//[^A-Za-z0-9_.-]/_}"
+    printf '%s' "$s"
+}
+
+run_cmd_json() {
+    local name="$1"
+    shift
+
+    local safe
+    safe="$(_safe_name "$name")"
+
+    local out="$TEMP_DIR/${safe}.out"
+    local err="$TEMP_DIR/${safe}.err"
+
+    set +e
+    "$@" >"$out" 2>"$err"
+    local rc=$?
+    set -e
+
+    if [[ $rc -ne 0 ]]; then
+        echo "Command failed ($name) rc=$rc:" >&2
+        printf '%q ' "$@" >&2
+        echo "" >&2
+        echo "stderr (first 200 lines):" >&2
+        sed -n '1,200p' "$err" >&2 || true
+        return "$rc"
+    fi
+
+    if ! python3 - "$out" <<'PY' >/dev/null 2>&1; then
+import json
+import sys
+raw = open(sys.argv[1], "r", encoding="utf-8", errors="replace").read().strip()
+obj = json.loads(raw)
+assert isinstance(obj, dict)
+PY
+        echo "stdout did not parse as a JSON object for: $name" >&2
+        echo "stdout (first 200 lines):" >&2
+        sed -n '1,200p' "$out" >&2 || true
+        echo "stderr (first 200 lines):" >&2
+        sed -n '1,200p' "$err" >&2 || true
+        return 1
+    fi
+
+    cat "$out"
+}
+
 # Find script directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$ROOT_DIR/scripts"
+
+# Preconditions
+require_cmd python3
+require_cmd nlm
+require_nlm_login
 
 # Validate helper scripts exist
 if [[ ! -x "$SCRIPT_DIR/create-notebook.sh" ]]; then
@@ -114,6 +235,81 @@ fi
 section "Integration Test Suite"
 info "Script directory: $SCRIPT_DIR"
 info "Temp directory: $TEMP_DIR"
+info "Options: keep_notebooks=$KEEP_NOTEBOOKS run_export_all=$RUN_EXPORT_ALL"
+
+# ============================================================================
+# Test 0: Quick CLI smoke (help and template rendering)
+# ============================================================================
+section "Test 0: CLI Smoke (Help + Templates)"
+
+set +e
+"$SCRIPT_DIR/generate-parallel.sh" --help >/dev/null 2>&1
+HP1=$?
+"$SCRIPT_DIR/create-from-template.sh" --help >/dev/null 2>&1
+HP2=$?
+"$SCRIPT_DIR/export-all.sh" --help >/dev/null 2>&1
+HP3=$?
+set -e
+
+if [[ $HP1 -eq 0 && $HP2 -eq 0 && $HP3 -eq 0 ]]; then
+    test_passed "Test 0 - help flags for key scripts"
+else
+    test_failed "Test 0 - help flags (generate-parallel/create-from-template/export-all)"
+fi
+
+# Validate templates render to valid JSON (does not call nlm).
+set +e
+NLM_ROOT="$ROOT_DIR" python3 - <<'PY'
+import json
+import os
+import subprocess
+from pathlib import Path
+
+root = Path(os.environ["NLM_ROOT"])
+templates = sorted((root / "templates").rglob("*.json"))
+assert templates, "no templates found"
+
+samples = {
+    "guest_name": "Ada Lovelace",
+    "topic": "computing",
+    "presentation_topic": "test topic",
+    "course_name": "Test Course",
+    "paper_topic": "Test Paper",
+}
+
+for t in templates:
+    data = json.loads(t.read_text(encoding="utf-8"))
+    # naive variable detection: {{var}}
+    needed = set()
+    def scan(obj):
+        if isinstance(obj, str):
+            for part in obj.split("{{")[1:]:
+                v = part.split("}}", 1)[0].strip()
+                if v:
+                    needed.add(v)
+        elif isinstance(obj, list):
+            for x in obj:
+                scan(x)
+        elif isinstance(obj, dict):
+            for x in obj.values():
+                scan(x)
+    scan(data)
+
+    args = ["python3", str(root / "lib" / "template_engine.py"), "render", str(t)]
+    # stdin is variables JSON
+    vars_json = {k: samples.get(k, "x") for k in needed}
+    p = subprocess.run(args, input=json.dumps(vars_json).encode("utf-8"), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert p.returncode == 0, f"render failed: {t} stderr={p.stderr.decode('utf-8', 'replace')[:500]}"
+    json.loads(p.stdout.decode("utf-8"))
+PY
+TEMPLATE_RC=$?
+set -e
+
+if [[ $TEMPLATE_RC -eq 0 ]]; then
+    test_passed "Test 0 - templates render to valid JSON"
+else
+    test_failed "Test 0 - templates render to valid JSON"
+fi
 
 # ============================================================================
 # Test 1: Create notebook with create-notebook.sh
@@ -123,42 +319,16 @@ section "Test 1: Notebook Creation"
 TEST_TITLE="Integration Test $(date +%s)"
 info "Creating notebook: $TEST_TITLE"
 
-set +e
-CREATE_STDERR="$TEMP_DIR/create-notebook.stderr"
-CREATE_OUTPUT=$("$SCRIPT_DIR/create-notebook.sh" --quiet "$TEST_TITLE" 2>"$CREATE_STDERR")
-CREATE_EXIT=$?
-set -e
-
-if [[ $CREATE_EXIT -ne 0 ]]; then
-    test_failed "Test 1 - create-notebook.sh failed"
-    cat "$CREATE_STDERR" || true
-else
-    # Extract notebook ID
-    NOTEBOOK_ID=$(echo "$CREATE_OUTPUT" | python3 -c "
-import sys, json, re
-output = sys.stdin.read()
-for line in output.split('\n'):
-    line = line.strip()
-    if line.startswith('{'):
-        try:
-            data = json.loads(line)
-            if 'id' in data:
-                print(data['id'])
-                sys.exit(0)
-        except:
-            continue
-match = re.search(r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', output)
-if match:
-    print(match.group(0))
-" 2>/dev/null)
-
-    if [[ -z "$NOTEBOOK_ID" ]]; then
-        test_failed "Test 1 - could not extract notebook ID"
-        echo "$CREATE_OUTPUT"
-    else
+if CREATE_OUTPUT="$(run_cmd_json "Test 1 - create-notebook.sh" "$SCRIPT_DIR/create-notebook.sh" --quiet "$TEST_TITLE")"; then
+    NOTEBOOK_ID="$(printf '%s' "$CREATE_OUTPUT" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)"
+    if [[ -n "${NOTEBOOK_ID:-}" ]]; then
         CREATED_NOTEBOOKS+=("$NOTEBOOK_ID")
         test_passed "Test 1 - created notebook $NOTEBOOK_ID"
+    else
+        test_failed "Test 1 - could not extract notebook ID"
     fi
+else
+    test_failed "Test 1 - create-notebook.sh failed"
 fi
 
 # ============================================================================
@@ -174,17 +344,7 @@ else
     TEST_URL="https://en.wikipedia.org/wiki/Artificial_intelligence"
     TEST_TEXT="text:This is a test source for integration testing. It contains basic information about AI and machine learning."
 
-    set +e
-    ADD_STDERR="$TEMP_DIR/add-sources.stderr"
-    ADD_OUTPUT=$("$SCRIPT_DIR/add-sources.sh" --quiet "$NOTEBOOK_ID" "$TEST_URL" "$TEST_TEXT" 2>"$ADD_STDERR")
-    ADD_EXIT=$?
-    set -e
-
-    if [[ $ADD_EXIT -ne 0 ]]; then
-        test_failed "Test 2 - add-sources.sh failed"
-        cat "$ADD_STDERR" || true
-    else
-        # Parse JSON output
+    if ADD_OUTPUT="$(run_cmd_json "Test 2 - add-sources.sh" "$SCRIPT_DIR/add-sources.sh" --quiet "$NOTEBOOK_ID" "$TEST_URL" "$TEST_TEXT")"; then
         SOURCES_ADDED=$(echo "$ADD_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sources_added', 0))" 2>/dev/null || echo "0")
         SOURCES_FAILED=$(echo "$ADD_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sources_failed', 0))" 2>/dev/null || echo "0")
 
@@ -193,6 +353,8 @@ else
         else
             test_failed "Test 2 - expected 2 sources added, got $SOURCES_ADDED added, $SOURCES_FAILED failed"
         fi
+    else
+        test_failed "Test 2 - add-sources.sh failed"
     fi
 fi
 
@@ -207,17 +369,7 @@ else
     info "Generating quiz artifact for notebook $NOTEBOOK_ID"
     info "This will take ~1 minute, please wait..."
 
-    set +e
-    STUDIO_STDERR="$TEMP_DIR/generate-studio.stderr"
-    STUDIO_OUTPUT=$("$SCRIPT_DIR/generate-studio.sh" --quiet "$NOTEBOOK_ID" quiz --wait 2>"$STUDIO_STDERR")
-    STUDIO_EXIT=$?
-    set -e
-
-    if [[ $STUDIO_EXIT -ne 0 ]]; then
-        test_failed "Test 3 - generate-studio.sh failed"
-        cat "$STUDIO_STDERR" || true
-    else
-        # Parse JSON output
+    if STUDIO_OUTPUT="$(run_cmd_json "Test 3 - generate-studio.sh (quiz --wait)" "$SCRIPT_DIR/generate-studio.sh" --quiet "$NOTEBOOK_ID" quiz --wait)"; then
         ARTIFACT_STATUS=$(echo "$STUDIO_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status', 'unknown'))" 2>/dev/null || echo "unknown")
 
         if [[ "$ARTIFACT_STATUS" == "completed" ]]; then
@@ -225,6 +377,28 @@ else
         else
             test_failed "Test 3 - quiz artifact status is '$ARTIFACT_STATUS' (expected 'completed')"
         fi
+    else
+        test_failed "Test 3 - generate-studio.sh failed"
+    fi
+fi
+
+# ============================================================================
+# Test 3b: Generate-parallel coverage (dry-run + live --wait)
+# ============================================================================
+section "Test 3b: Parallel Generation Coverage"
+
+if [[ -z "${NOTEBOOK_ID:-}" ]]; then
+    test_failed "Test 3b - skipped (no notebook from Test 1)"
+else
+    if run_cmd_json "Test 3b - generate-parallel.sh (--dry-run)" "$SCRIPT_DIR/generate-parallel.sh" --quiet --dry-run "$NOTEBOOK_ID" quiz,report --wait >/dev/null; then
+        test_passed "Test 3b - generate-parallel.sh (--dry-run)"
+    else
+        test_failed "Test 3b - generate-parallel.sh (--dry-run)"
+    fi
+    if run_cmd_json "Test 3b - generate-parallel.sh (--wait)" "$SCRIPT_DIR/generate-parallel.sh" --quiet "$NOTEBOOK_ID" quiz --wait >/dev/null; then
+        test_passed "Test 3b - generate-parallel.sh (--wait)"
+    else
+        test_failed "Test 3b - generate-parallel.sh (--wait)"
     fi
 fi
 
@@ -244,24 +418,16 @@ else
     if [[ ! -x "$SCRIPT_DIR/export-notebook.sh" ]]; then
         test_failed "Test 4 - export-notebook.sh not found or not executable"
     else
-        set +e
-        EXPORT_STDERR="$TEMP_DIR/export-notebook.stderr"
-        "$SCRIPT_DIR/export-notebook.sh" --quiet --id "$NOTEBOOK_ID" --output "$EXPORT_DIR" 1>/dev/null 2>"$EXPORT_STDERR"
-        EXPORT_EXIT=$?
-        set -e
-
-        if [[ $EXPORT_EXIT -ne 0 ]]; then
+        if ! run_cmd_json "Test 4 - export-notebook.sh" "$SCRIPT_DIR/export-notebook.sh" --quiet --id "$NOTEBOOK_ID" --output "$EXPORT_DIR" >/dev/null; then
             test_failed "Test 4 - export-notebook.sh failed"
-            cat "$EXPORT_STDERR" || true
-        else
-            # Check if files were created
-            FILE_COUNT=$(find "$EXPORT_DIR" -type f | wc -l | tr -d ' ')
+        fi
 
-            if [[ "$FILE_COUNT" -gt 0 ]]; then
-                test_passed "Test 4 - exported notebook ($FILE_COUNT files)"
-            else
-                test_failed "Test 4 - no files were exported"
-            fi
+        # Check if files were created
+        FILE_COUNT=$(find "$EXPORT_DIR" -type f | wc -l | tr -d ' ')
+        if [[ "$FILE_COUNT" -gt 0 ]]; then
+            test_passed "Test 4 - exported notebook ($FILE_COUNT files)"
+        else
+            test_failed "Test 4 - no files were exported"
         fi
     fi
 fi
@@ -292,16 +458,7 @@ EOF
 info "Created test config: $CONFIG_FILE"
 info "Running end-to-end automation (this will take ~1-2 minutes)..."
 
-set +e
-E2E_STDERR="$TEMP_DIR/automate-notebook.stderr"
-E2E_OUTPUT=$("$SCRIPT_DIR/automate-notebook.sh" --quiet --config "$CONFIG_FILE" 2>"$E2E_STDERR")
-E2E_EXIT=$?
-set -e
-
-if [[ $E2E_EXIT -ne 0 ]]; then
-    test_failed "Test 5 - automate-notebook.sh failed"
-    cat "$E2E_STDERR" || true
-else
+if E2E_OUTPUT="$(run_cmd_json "Test 5 - automate-notebook.sh" "$SCRIPT_DIR/automate-notebook.sh" --quiet --config "$CONFIG_FILE")"; then
     # Parse JSON output (stdout is reserved for JSON)
     E2E_NOTEBOOK_ID=$(echo "$E2E_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('notebook_id', ''))" 2>/dev/null || echo "")
     E2E_SOURCES_ADDED=$(echo "$E2E_OUTPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sources_added', 0))" 2>/dev/null || echo "0")
@@ -317,6 +474,25 @@ else
     else
         test_failed "Test 5 - unexpected results (notebook: $E2E_NOTEBOOK_ID, sources: $E2E_SOURCES_ADDED, artifacts: $E2E_ARTIFACTS_CREATED)"
     fi
+else
+    test_failed "Test 5 - automate-notebook.sh failed"
+fi
+
+# ============================================================================
+# Optional: export-all.sh (dangerous; exports all notebooks)
+# ============================================================================
+section "Optional: export-all.sh"
+if [[ "$RUN_EXPORT_ALL" == true ]]; then
+    EXPORT_ALL_DIR="$TEMP_DIR/export-all"
+    mkdir -p "$EXPORT_ALL_DIR"
+    info "Running export-all.sh to $EXPORT_ALL_DIR (this exports ALL notebooks and may take a long time)"
+    if run_cmd_json "Optional - export-all.sh" "$SCRIPT_DIR/export-all.sh" --quiet --output "$EXPORT_ALL_DIR" --continue-on-error >/dev/null; then
+        test_passed "Optional - export-all.sh"
+    else
+        test_failed "Optional - export-all.sh"
+    fi
+else
+    warn "Skipping export-all.sh (pass --run-export-all to enable)"
 fi
 
 # ============================================================================


### PR DESCRIPTION
Closes #33.

Changes:
- Expanded `tests/integration-test.sh` to be resilient to the stdout JSON contract (captures stdout JSON, prints stderr only on failure).
- Added coverage for:
  - `generate-parallel.sh` (dry-run + live --wait)
  - help flags for `generate-parallel.sh`, `create-from-template.sh`, `export-all.sh`
  - template rendering validation (renders all templates to JSON; no `nlm` calls)
- Added documented manual workflow for running tests in `README.md` and `CONTRIBUTING.md`.

Notes:
- Integration tests still require a real `nlm login` and are not run in CI by default.
- `export-all.sh` is included as an opt-in integration step via `./tests/integration-test.sh --run-export-all`.

Local verification (no-auth):
- `bash -n scripts/*.sh`
- `shellcheck -x scripts/*.sh`
- `python3 -m py_compile lib/*.py`
- `bash tests/help-flags-test.sh`
- `bash tests/dry-run-smoke-test.sh`

Integration-test preflight verified:
- `./tests/integration-test.sh` now fails fast with an actionable message if `nlm login` is missing.
