### PR TITLE
P1: template engine missing-var checks + defaults

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Dry-run smoke tests (no auth)
         run: bash tests/dry-run-smoke-test.sh
 
+      - name: Template engine self-test
+        run: bash tests/template-engine-test.sh
+
       - name: Python compile
         run: python3 -m py_compile lib/*.py
 

--- a/lib/template_engine.py
+++ b/lib/template_engine.py
@@ -5,15 +5,34 @@ Template engine for NotebookLM automation.
 
 import sys
 import json
+import re
 from pathlib import Path
 from typing import Dict, Any, List
+
+_PLACEHOLDER_RE = re.compile(r"{{\s*([a-zA-Z0-9_]+)\s*}}")
 
 def load_template(template_path: str) -> Dict[str, Any]:
     """Load template JSON file."""
     with open(template_path, 'r') as f:
         return json.load(f)
 
-def interpolate_variables(template: Dict, variables: Dict[str, str]) -> Dict:
+def _find_placeholders(value: Any) -> List[str]:
+    """Collect placeholder variable names ({{var}}) from any nested JSON-like value."""
+    found: List[str] = []
+    if isinstance(value, str):
+        found.extend(m.group(1) for m in _PLACEHOLDER_RE.finditer(value))
+        return found
+    if isinstance(value, dict):
+        for v in value.values():
+            found.extend(_find_placeholders(v))
+        return found
+    if isinstance(value, list):
+        for v in value:
+            found.extend(_find_placeholders(v))
+        return found
+    return found
+
+def interpolate_variables(template: Any, variables: Dict[str, str]) -> Any:
     """
     Replace {{variable}} placeholders in template.
 
@@ -21,11 +40,14 @@ def interpolate_variables(template: Dict, variables: Dict[str, str]) -> Dict:
     """
     def interpolate_value(value):
         if isinstance(value, str):
-            # Replace all {{var}} with values
-            for key, val in variables.items():
-                placeholder = f"{{{{{key}}}}}"
-                value = value.replace(placeholder, val)
-            return value
+            def _repl(match: re.Match) -> str:
+                key = match.group(1)
+                if key in variables:
+                    return str(variables[key])
+                # Leave unresolved placeholders intact for reporting.
+                return match.group(0)
+
+            return _PLACEHOLDER_RE.sub(_repl, value)
         elif isinstance(value, dict):
             return {k: interpolate_value(v) for k, v in value.items()}
         elif isinstance(value, list):
@@ -54,6 +76,64 @@ def list_templates(templates_dir: str = "templates") -> List[Dict[str, str]]:
 
     return templates
 
+def _normalize_vars(obj: Any) -> Dict[str, str]:
+    if obj is None:
+        return {}
+    if not isinstance(obj, dict):
+        raise ValueError("template variables must be a JSON object")
+    out: Dict[str, str] = {}
+    for k, v in obj.items():
+        if not isinstance(k, str):
+            raise ValueError("template variable keys must be strings")
+        if isinstance(v, (str, int, float, bool)) or v is None:
+            out[k] = "" if v is None else str(v)
+        else:
+            raise ValueError(f"template variable '{k}' must be a string/number/bool/null")
+    return out
+
+def _extract_template_meta(template: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Optional metadata block. If present, it is removed from the rendered output.
+
+    Supported keys:
+      - required: list[str]
+      - defaults: dict[str, str]
+      - allow_unresolved: bool (if true, skip placeholder checks)
+    """
+    meta = template.get("_template")
+    if not isinstance(meta, dict):
+        return {}
+    return meta
+
+def _render_strict(template: Dict[str, Any], input_vars: Dict[str, str], allow_unresolved: bool) -> Dict[str, Any]:
+    meta = _extract_template_meta(template)
+
+    # Remove metadata from output config if present.
+    if "_template" in template:
+        template = dict(template)
+        template.pop("_template", None)
+
+    defaults = meta.get("defaults") if isinstance(meta.get("defaults"), dict) else {}
+    variables = dict(_normalize_vars(defaults))
+    variables.update(_normalize_vars(input_vars))
+
+    required = meta.get("required") if isinstance(meta.get("required"), list) else None
+    if required is None:
+        required_set = set(_find_placeholders(template))
+    else:
+        required_set = set(x for x in required if isinstance(x, str))
+
+    missing = sorted(v for v in required_set if v not in variables)
+    if missing and not allow_unresolved and not bool(meta.get("allow_unresolved", False)):
+        raise ValueError("Missing template variables: " + ", ".join(missing))
+
+    rendered = interpolate_variables(template, variables)
+    unresolved = sorted(set(_find_placeholders(rendered)))
+    if unresolved and not allow_unresolved and not bool(meta.get("allow_unresolved", False)):
+        raise ValueError("Unresolved template placeholders remain: " + ", ".join(unresolved))
+
+    return rendered
+
 def main() -> None:
     """CLI interface."""
     if len(sys.argv) < 2:
@@ -71,26 +151,41 @@ def main() -> None:
         print(json.dumps(templates, indent=2))
 
     elif command == 'render':
-        if len(sys.argv) < 3:
-            print("Usage: template_engine.py render <template.json> [vars.json]")
+        allow_unresolved = False
+        args = sys.argv[2:]
+        if "--allow-unresolved" in args:
+            allow_unresolved = True
+            args = [a for a in args if a != "--allow-unresolved"]
+
+        if len(args) < 1:
+            print("Usage: template_engine.py render <template.json> [vars.json] [--allow-unresolved]", file=sys.stderr)
             sys.exit(1)
 
-        template_path = sys.argv[2]
+        template_path = args[0]
         template = load_template(template_path)
 
         # Load variables from file or stdin
-        if len(sys.argv) >= 4:
-            with open(sys.argv[3], 'r') as f:
-                variables = json.load(f)
+        if len(args) >= 2:
+            with open(args[1], 'r') as f:
+                variables_obj = json.load(f)
         else:
             # Read from stdin if available
             if not sys.stdin.isatty():
-                variables = json.load(sys.stdin)
+                raw = sys.stdin.read()
+                if raw.strip() == "":
+                    variables_obj = {}
+                else:
+                    variables_obj = json.loads(raw)
             else:
-                variables = {}
+                variables_obj = {}
 
-        # Render template
-        rendered = interpolate_variables(template, variables)
+        try:
+            variables = _normalize_vars(variables_obj)
+            rendered = _render_strict(template, variables, allow_unresolved=allow_unresolved)
+        except Exception as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(2)
+
         print(json.dumps(rendered, indent=2))
 
     else:

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,6 +2,27 @@
 
 Pre-built templates for common NotebookLM workflows.
 
+## Template variables and validation
+
+`create-from-template.sh` renders templates by substituting `{{snake_case}}` placeholders.
+
+By default, rendering is strict:
+- If any required variables are missing, rendering fails with a clear list of missing variable names.
+- If any `{{...}}` placeholders remain after rendering, rendering fails.
+
+You can optionally add a metadata block to any template under the `_template` key. This block is removed from the final rendered config:
+
+```json
+{
+  "_template": {
+    "required": ["paper_topic"],
+    "defaults": {"depth": "10"}
+  },
+  "title": "Research: {{paper_topic}}",
+  "smart_creation": {"enabled": true, "topic": "{{paper_topic}}", "depth": "{{depth}}"}
+}
+```
+
 ## Available Templates
 
 ### Research Templates

--- a/tests/template-engine-test.sh
+++ b/tests/template-engine-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+tmpdir="$(mktemp -d -t nlm-template-test.XXXXXX)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() { echo "template engine test failed: $*" >&2; exit 1; }
+
+tmpl="$tmpdir/t.json"
+cat >"$tmpl" <<'EOF'
+{
+  "title": "Hello {{name}}",
+  "smart_creation": {
+    "enabled": true,
+    "topic": "{{topic}}"
+  }
+}
+EOF
+
+# Missing vars should fail with a clear message.
+set +e
+err="$tmpdir/err"
+python3 "$ROOT_DIR/lib/template_engine.py" render "$tmpl" >"$tmpdir/out" 2>"$err"
+rc=$?
+set -e
+[[ $rc -ne 0 ]] || fail "expected non-zero exit for missing vars"
+rg -q "Missing template variables: name, topic|Missing template variables: topic, name" "$err" || fail "missing vars message not found"
+
+# Providing vars should succeed and leave no placeholders.
+vars="$tmpdir/vars.json"
+cat >"$vars" <<'EOF'
+{"name":"World","topic":"test"}
+EOF
+python3 "$ROOT_DIR/lib/template_engine.py" render "$tmpl" "$vars" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d["title"]=="Hello World"; assert d["smart_creation"]["topic"]=="test"'
+
+# --allow-unresolved should permit missing variables.
+python3 "$ROOT_DIR/lib/template_engine.py" render "$tmpl" --allow-unresolved | python3 -c 'import json,sys; d=json.load(sys.stdin); assert "{{name}}" in d["title"]'
+
+echo "template engine tests: ok"
+

--- a/tests/template-engine-test.sh
+++ b/tests/template-engine-test.sh
@@ -26,7 +26,7 @@ python3 "$ROOT_DIR/lib/template_engine.py" render "$tmpl" >"$tmpdir/out" 2>"$err
 rc=$?
 set -e
 [[ $rc -ne 0 ]] || fail "expected non-zero exit for missing vars"
-rg -q "Missing template variables: name, topic|Missing template variables: topic, name" "$err" || fail "missing vars message not found"
+grep -Eq "Missing template variables: (name, topic|topic, name)" "$err" || fail "missing vars message not found"
 
 # Providing vars should succeed and leave no placeholders.
 vars="$tmpdir/vars.json"
@@ -39,4 +39,3 @@ python3 "$ROOT_DIR/lib/template_engine.py" render "$tmpl" "$vars" | python3 -c '
 python3 "$ROOT_DIR/lib/template_engine.py" render "$tmpl" --allow-unresolved | python3 -c 'import json,sys; d=json.load(sys.stdin); assert "{{name}}" in d["title"]'
 
 echo "template engine tests: ok"
-


### PR DESCRIPTION
Closes #13.

Improvements:
- `lib/template_engine.py` now fails fast with a clear error if required variables are missing or if any `{{...}}` placeholders remain after rendering.
- Adds optional `_template` metadata block support:
  - `_template.required`: explicit list of required vars (otherwise inferred from placeholders)
  - `_template.defaults`: default vars merged in when not provided
  - `_template.allow_unresolved`: opt out of strict checks
- Adds `--allow-unresolved` flag for CLI consumers.
- Makes `render` tolerate empty stdin (treats as `{}`) for non-interactive callers.

Docs/tests:
- Documents strict rendering + `_template` metadata in `templates/README.md`.
- Adds `tests/template-engine-test.sh` and wires it into static checks.

Local verification:
- `python3 -m py_compile lib/*.py`
- `bash tests/template-engine-test.sh`
- `bash tests/dry-run-smoke-test.sh`
- `shellcheck -x scripts/*.sh`
