### PR TITLE
P1: deterministic export ordering + stable filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,12 +109,12 @@ exports/
     ├── metadata.json           # Notebook metadata
     ├── sources/
     │   ├── index.json         # Source list
-    │   └── *.md               # Source content
+    │   └── *--<source-id>.md  # Source content (stable filenames)
     ├── chat/
     │   └── index.json         # Empty (API limitation)
     ├── notes/
     │   ├── index.json         # Notes list
-    │   └── *.md               # Individual notes
+    │   └── *--<note-id>.md    # Individual notes (stable filenames)
     └── studio/
         ├── manifest.json      # Artifact list
         ├── audio/


### PR DESCRIPTION
Closes #11.

Changes:
- `scripts/export-notebook.sh` now writes deterministic JSON files:
  - `metadata.json` uses sorted keys
  - `sources/index.json`, `notes/index.json`, `studio/manifest.json` are sorted before writing
- Source and note markdown filenames now include their IDs (`*--<id>.md`) to avoid collisions and ensure stable naming.
- README export structure updated to reflect stable filenames.

Safety:
- Sorting steps are resilient to non-JSON `nlm` output (fallback to empty arrays).

Local verification:
- `bash -n scripts/*.sh`
- `shellcheck -x scripts/*.sh`
- `bash tests/dry-run-smoke-test.sh`
