### PR TITLE
P1: smarter research quality controls (allow/deny domains + scholarly mode)

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Template engine self-test
         run: bash tests/template-engine-test.sh
 
+      - name: Web search filter self-test
+        run: bash tests/web-search-filter-test.sh
+
       - name: Python compile
         run: python3 -m py_compile lib/*.py
 

--- a/lib/web_search.py
+++ b/lib/web_search.py
@@ -7,7 +7,16 @@ import sys
 import json
 from typing import List, Dict
 from urllib.parse import urlparse
-from ddgs import DDGS
+
+def _norm_netloc(url: str) -> str:
+    netloc = urlparse(url).netloc.lower()
+    if netloc.startswith("www."):
+        netloc = netloc[4:]
+    return netloc
+
+def _domain_matches(netloc: str, domain: str) -> bool:
+    domain = domain.lower().lstrip(".")
+    return netloc == domain or netloc.endswith("." + domain)
 
 def search_web(query: str, max_results: int = 10) -> List[Dict[str, str]]:
     """
@@ -17,6 +26,7 @@ def search_web(query: str, max_results: int = 10) -> List[Dict[str, str]]:
     """
     results = []
     try:
+        from ddgs import DDGS  # type: ignore
         with DDGS() as ddgs:
             for r in ddgs.text(query, max_results=max_results):
                 results.append({
@@ -29,7 +39,13 @@ def search_web(query: str, max_results: int = 10) -> List[Dict[str, str]]:
 
     return results
 
-def filter_quality_sources(results: List[Dict], min_snippet_length: int = 50) -> List[Dict]:
+def filter_quality_sources(
+    results: List[Dict],
+    min_snippet_length: int = 50,
+    allow_domains: List[str] = None,
+    deny_domains: List[str] = None,
+    explain: bool = False,
+) -> List[Dict]:
     """
     Filter search results for quality sources.
 
@@ -39,40 +55,101 @@ def filter_quality_sources(results: List[Dict], min_snippet_length: int = 50) ->
     - Title is descriptive
     """
     spam_domains = ['pinterest.com', 'instagram.com', 'facebook.com']
+    allow_domains = allow_domains or []
+    deny_domains = deny_domains or []
 
     filtered = []
+    rejected_counts: Dict[str, int] = {}
     for r in results:
-        netloc = urlparse(r.get('url', '')).netloc.lower()
-        if netloc.startswith('www.'):
-            netloc = netloc[4:]
+        url = r.get('url', '')
+        netloc = _norm_netloc(url)
+        if not netloc:
+            rejected_counts["invalid_url"] = rejected_counts.get("invalid_url", 0) + 1
+            continue
 
         # Skip spam domains
-        if any(netloc == domain or netloc.endswith('.' + domain) for domain in spam_domains):
+        if any(_domain_matches(netloc, domain) for domain in spam_domains):
+            rejected_counts["spam_domain"] = rejected_counts.get("spam_domain", 0) + 1
+            continue
+
+        # Deny-list wins
+        if deny_domains and any(_domain_matches(netloc, d) for d in deny_domains):
+            rejected_counts["deny_domain"] = rejected_counts.get("deny_domain", 0) + 1
+            continue
+
+        # Allow-list (if provided) restricts matches
+        if allow_domains and not any(_domain_matches(netloc, d) for d in allow_domains):
+            rejected_counts["allow_domain_miss"] = rejected_counts.get("allow_domain_miss", 0) + 1
             continue
 
         # Require minimum snippet length
         if len(r.get('snippet', '')) < min_snippet_length:
+            rejected_counts["snippet_too_short"] = rejected_counts.get("snippet_too_short", 0) + 1
             continue
 
         # Require title
         if not r.get('title'):
+            rejected_counts["title_missing"] = rejected_counts.get("title_missing", 0) + 1
             continue
 
         filtered.append(r)
+
+    if explain and rejected_counts:
+        parts = [f"{k}={v}" for k, v in sorted(rejected_counts.items())]
+        print("[web_search] filtered_out: " + " ".join(parts), file=sys.stderr)
 
     return filtered
 
 def main():
     """CLI interface for web search."""
     if len(sys.argv) < 2:
-        print("Usage: web_search.py <query> [max_results]")
+        print("Usage: web_search.py <query> [max_results] [--allow-domains a,b] [--deny-domains x,y] [--mode scholarly] [--explain]", file=sys.stderr)
         sys.exit(1)
 
-    query = sys.argv[1]
-    max_results = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+    args = sys.argv[1:]
+    query = args[0]
+    i = 1
 
-    results = search_web(query, max_results)
-    filtered = filter_quality_sources(results)
+    max_results = 10
+    if i < len(args) and not args[i].startswith("--"):
+        max_results = int(args[i])
+        i += 1
+
+    allow_domains: List[str] = []
+    deny_domains: List[str] = []
+    mode = ""
+    explain = False
+
+    while i < len(args):
+        a = args[i]
+        if a == "--allow-domains":
+            i += 1
+            allow_domains = [x.strip() for x in args[i].split(",") if x.strip()]
+        elif a == "--deny-domains":
+            i += 1
+            deny_domains = [x.strip() for x in args[i].split(",") if x.strip()]
+        elif a == "--mode":
+            i += 1
+            mode = args[i].strip()
+        elif a == "--explain":
+            explain = True
+        else:
+            print(f"Unknown option: {a}", file=sys.stderr)
+            sys.exit(2)
+        i += 1
+
+    query_final = query
+    if mode == "scholarly":
+        # Heuristic: bias toward academic/public-sector sources and PDFs.
+        query_final = f'{query} (site:edu OR site:ac.uk OR site:gov OR filetype:pdf)'
+
+    results = search_web(query_final, max_results)
+    filtered = filter_quality_sources(
+        results,
+        allow_domains=allow_domains,
+        deny_domains=deny_domains,
+        explain=explain,
+    )
 
     print(json.dumps(filtered, indent=2))
 

--- a/tests/web-search-filter-test.sh
+++ b/tests/web-search-filter-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python3 - <<'PY'
+import sys
+
+sys.path.insert(0, ".")
+
+from lib.web_search import filter_quality_sources  # type: ignore
+
+results = [
+    {"title": "Spam", "url": "https://pinterest.com/x", "snippet": "x" * 200},
+    {"title": "", "url": "https://example.com/no-title", "snippet": "x" * 200},
+    {"title": "Short", "url": "https://example.com/short", "snippet": "x" * 10},
+    {"title": "Good A", "url": "https://example.com/a", "snippet": "x" * 200},
+    {"title": "Good Sub", "url": "https://sub.example.com/b", "snippet": "x" * 200},
+    {"title": "Denied", "url": "https://deny.example.com/c", "snippet": "x" * 200},
+]
+
+# Baseline: spam, missing title, short snippet filtered out.
+filtered = filter_quality_sources(results, explain=False)
+urls = {r["url"] for r in filtered}
+assert "https://example.com/a" in urls
+assert "https://sub.example.com/b" in urls
+assert "https://pinterest.com/x" not in urls
+assert "https://example.com/no-title" not in urls
+assert "https://example.com/short" not in urls
+
+# Allow list restricts to example.com (incl subdomains).
+filtered = filter_quality_sources(results, allow_domains=["example.com"], explain=False)
+urls = {r["url"] for r in filtered}
+assert urls == {"https://example.com/a", "https://sub.example.com/b", "https://deny.example.com/c"}
+
+# Deny list removes matching domains, including subdomains.
+filtered = filter_quality_sources(
+    results,
+    allow_domains=["example.com"],
+    deny_domains=["deny.example.com"],
+    explain=False,
+)
+urls = {r["url"] for r in filtered}
+assert urls == {"https://example.com/a", "https://sub.example.com/b"}
+
+print("web search filter tests: ok")
+PY
+


### PR DESCRIPTION
Closes #14.

Adds optional source-quality controls for smart creation:
- `scripts/research-topic.sh`:
  - `--allow-domains a,b` restricts sources to a domain allow-list
  - `--deny-domains x,y` filters out a domain deny-list (wins over allow)
  - `--mode scholarly` applies a heuristic query bias toward academic/public-sector sources and PDFs
  - outputs include filtering summaries (suppressed under `--quiet`; per-URL reasons under `--verbose`)
- `lib/web_search.py`:
  - supports `--allow-domains`, `--deny-domains`, `--mode scholarly`, `--explain`
  - lazily imports `ddgs` so `py_compile` and no-auth tests don’t require the optional dependency

Tests/CI:
- Adds `tests/web-search-filter-test.sh` (unit tests domain allow/deny logic) and wires into static checks.

Local verification:
- `python3 -m py_compile lib/*.py`
- `bash tests/web-search-filter-test.sh`
- `bash -n scripts/*.sh`
- `shellcheck -x scripts/*.sh`
